### PR TITLE
fix: streamline error logging structure in ErrorData and response pac…

### DIFF
--- a/libError/errordata.go
+++ b/libError/errordata.go
@@ -36,12 +36,10 @@ func (e ErrorData) LogValue() slog.Value {
 		src = slog.Attr{}
 	}
 	return slog.GroupValue(
-		slog.Group("error",
-			slog.Time("time", e.Time),
-			slog.String("desc", e.ActionData.Description),
-			slog.Any("action", e.ActionData),
-			src,
-			slog.Any("child", e.Child),
-		),
+		slog.Time("time", e.Time),
+		slog.String("desc", e.ActionData.Description),
+		slog.Any("action", e.ActionData),
+		src,
+		slog.Any("child", e.Child),
 	)
 }

--- a/response/errorData.go
+++ b/response/errorData.go
@@ -33,13 +33,11 @@ func (e ErrorData) LogValue() slog.Value {
 		children = append(children, slog.Any(e.childs[id].GetDescription(), e.childs[id]))
 	}
 	return slog.GroupValue(
-		slog.Group("error",
-			slog.Int("status", e.Status),
-			slog.String("desc", e.Description),
-			slog.Any("message", e.Message),
-			slog.Any("source", e.source),
-			slog.Group("children", children...),
-		),
+		slog.Int("status", e.Status),
+		slog.String("desc", e.Description),
+		slog.Any("message", e.Message),
+		slog.Any("source", e.source),
+		slog.Group("children", children...),
 	)
 }
 

--- a/response/webHandler.go
+++ b/response/webHandler.go
@@ -2,6 +2,7 @@ package response
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -36,7 +37,7 @@ func getList(err error) []error {
 func (m WebHanlder) errorhandler(w webFramework.WebFramework, err error) {
 	array := getList(err)
 	for id := range array {
-		webFramework.AddLogTag(w, webFramework.ErrorListLogTag, slog.Any(array[id].Error(), array[id]))
+		webFramework.AddLogTag(w, webFramework.ErrorListLogTag, slog.Any(fmt.Sprintf("error-%d", id), array[id]))
 	}
 	if newError := getError[libError.ErrorData](err); newError != nil {
 		m.Respond(newError.ActionData.Status.Int(), 1, newError.ActionData.Description, newError.ActionData.Message, true, w)
@@ -47,7 +48,7 @@ func (m WebHanlder) errorhandler(w webFramework.WebFramework, err error) {
 		return
 	}
 
-	webFramework.AddLogTag(w, webFramework.ErrorListLogTag, slog.Any(err.Error(), err))
+	webFramework.AddLogTag(w, webFramework.ErrorListLogTag, slog.Any("error", err))
 	desc := err.Error()
 	desc = strings.ToUpper(desc)
 	desc = strings.ReplaceAll(desc, " ", "")


### PR DESCRIPTION
…kage

- Removed unnecessary grouping in LogValue methods for ErrorData in both libError and response packages.
- Updated error logging in webHandler to use a more descriptive format for error tags.